### PR TITLE
remove macos-13 from the matrix

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -39,10 +39,6 @@ jobs:
             cpu: amd64
             platform: x64
             builder: ubuntu-24.04
-          - os: macos
-            cpu: amd64
-            platform: x64
-            builder: macos-13
           - os: windows
             cpu: amd64
             platform: x64


### PR DESCRIPTION
It is no longer supported, starting from September 1st: https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down