### PR TITLE
different way to fetch Nim commit hash

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -162,11 +162,18 @@ jobs:
 
       - name: Get Nim commit hash
         id: nim-hash
-        run: |
-          BRANCH="${{ matrix.branch }}"
-          HASH=$(curl -s "https://api.github.com/repos/nim-lang/Nim/branches/${{ matrix.branch }}" | jq -r .commit.sha)
-          echo "NIM_COMMIT_HASH=$HASH" >> $GITHUB_ENV
-          echo "nim_commit_hash=$HASH" >> $GITHUB_OUTPUT
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const branch = "${{ matrix.branch }}";
+            const res = await github.rest.repos.getBranch({
+              owner: "nim-lang",
+              repo: "Nim",
+              branch: branch,
+            });
+            const sha = res.data.commit.sha;
+            core.setOutput("nim_commit_hash", sha);
+            core.exportVariable("NIM_COMMIT_HASH", sha);
 
       - name: Restore Nim build from cache
         id: nim-cache


### PR DESCRIPTION
The old way was hitting rate limits and silently failing, which introduced a subtle bug on macos runners, ignoring new Nim commits since it always used `null` as a Nim commit hash.