### PR TITLE
Nimble install with `--useSystemNim`

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -237,5 +237,5 @@ jobs:
           nim --version
           nimble --version
           gcc --version
-          nimble install -y --depsOnly
+          nimble --useSystemNim install -y --depsOnly
           ${{ inputs.test-command }}


### PR DESCRIPTION
otherwise nimble may install and use a different Nim version than the one intended to be tested...