### PR TITLE
Add linux arm64 to matrix

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -57,6 +57,10 @@ jobs:
             cpu: i386
             platform: x86
             builder: ubuntu-latest
+          - os: linux
+            cpu: arm64
+            platform: arm64
+            builder: ubuntu-24.04-arm
           - os: macos
             cpu: amd64
             platform: x64


### PR DESCRIPTION
Consider adding linux arm64 given it's a nimbus-eth1 target. Idk if there is a reason not to add it.